### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+mtree-netbsd (20180822-8) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on libnbcompat-dev (>=
+      20180822-5).
+    + Build-Depends: Replace dependency on transitional package bsdtar with
+      replacement libarchive-tools (>= 3.3.3-4+deb10u1).
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 04 Jan 2023 21:32:41 -0000
+
 mtree-netbsd (20180822-7) unstable; urgency=medium
 
   * [Helmut Grohne] Properly handle DEB_BUILD_OPTIONS=nocheck.  Closes: #1003640.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: mtree-netbsd
 Section: utils
 Priority: optional
 Maintainer: John Goerzen <jgoerzen@complete.org>
-Build-Depends: debhelper (>= 9), autotools-dev, bmake, libnbcompat-dev (>= 20180822-5), libarchive-tools | bsdtar, libncurses-dev, libbsd-dev, libmd-dev
+Build-Depends: debhelper (>= 9), autotools-dev, bmake, libnbcompat-dev, libarchive-tools | libarchive-tools (>= 3.3.3-4+deb10u1), libncurses-dev, libbsd-dev, libmd-dev
 Standards-Version: 4.4.1
 Homepage: http://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/pkgtools/mtree/README.html
 Vcs-Git: https://github.com/jgoerzen/mtree-netbsd.git


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/77/068e51043666c0e7e9ffbf1e781f250742576a.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a0/999cf3e4887bf73020ccacf86e17c90c0b1339.debug

No differences were encountered between the control files of package \*\*mtree-netbsd\*\*
### Control files of package mtree-netbsd-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-a0999cf3e4887bf73020ccacf86e17c90c0b1339-] {+77068e51043666c0e7e9ffbf1e781f250742576a+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/968a37e0-cd8d-4672-9daa-ff17e73da711/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/968a37e0-cd8d-4672-9daa-ff17e73da711/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/mtree-netbsd/968a37e0-cd8d-4672-9daa-ff17e73da711.